### PR TITLE
chore: Bump to version 1.6.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
         fetch-depth: 0
     - name: Download changelog cli
       run: |
-        curl -L -o changelog-cli https://github.com/monta-app/changelog-cli/releases/download/v1.6.0/changelog-cli
+        curl -L -o changelog-cli https://github.com/monta-app/changelog-cli/releases/download/v1.6.1/changelog-cli
         chmod +x ./changelog-cli
       shell: bash
     - name: Run changelog cli


### PR DESCRIPTION
AFTER https://github.com/monta-app/changelog-cli/pull/80 and releasing