### PR TITLE
fix: Update changelog cli from 1.6.2 to 1.8.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
       shell: bash
     - name: Download changelog cli
       run: |
-        curl -L -o changelog-cli https://github.com/monta-app/changelog-cli/releases/download/v1.6.2/changelog-cli
+        curl -L -o changelog-cli https://github.com/monta-app/changelog-cli/releases/download/v1.8.0/changelog-cli
         chmod +x ./changelog-cli
       shell: bash
     - name: Run changelog cli


### PR DESCRIPTION
Unknown why we never used [v1.7.0](https://github.com/monta-app/changelog-cli/releases/tag/v1.7.0)

This will upgrade a number of things
* 1.6.2 -> 1.7.0 [changes](https://github.com/monta-app/changelog-cli/compare/v1.6.2...v1.7.0)
  * @BrianEstrada this will change this behaviour [feature: scopes that are written in kebab case are now converted to capital case](https://github.com/monta-app/changelog-cli/commit/31b4bca66cc9d9318d4a087e65e36fc0f43a1f3c) that you introduced back in October 2023
* 1.7.0 -> 1.8.0 [changes](https://github.com/monta-app/changelog-cli/compare/v1.7.0...v1.8.0)
  * @cweinberger this will change this behaviour [chore: Improve readability of scopes when using dashed](https://github.com/monta-app/changelog-cli/commit/cd2e6627247e4eda2bb86b72b9554756d92c66a7) that you introduced back in November 2023