### PR TITLE
chore: update repo ownership to match current org [SRE-314]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,29 +1,26 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  # Name of the project 
+  # Name of the project
   name: changelog-cli-action
   description: GitHub action for our Changelog CLI
   # Specifies the directory of the docs
   annotations:
     backstage.io/techdocs-ref: dir:.
-    
   labels:
     tier: '3'
-
   # These links are just examples, set them to what you think is the most relevant.
   links:
-    # Page in notion documenting the purpose and function of the service 
-  - title: Notion
-    url: https://www.notion.so/montaapp/changelog-cli-88c53f278ce44b599d9dff5e4f760e2d?pvs=4
-    type: Notion
-    icon: docs
-
+    # Page in notion documenting the purpose and function of the service
+    - title: Notion
+      url: https://www.notion.so/montaapp/changelog-cli-88c53f278ce44b599d9dff5e4f760e2d?pvs=4
+      type: Notion
+      icon: docs
 # The spec defines who becomes the owner of the system in backstage
 spec:
   type: cli
   lifecycle: production
   # Name of the squad responsible for the project, e.g. sre or cpi
-  owner: SRE
+  owner: sre
   # Name of the greater system, e.g. "solar" is a part of the home system
-  system: Platform
+  system: platform-division


### PR DESCRIPTION
### Changes

Set squad owner and division in  to match new org structure

### Motivation

Make sure code repository ownership reflect the current organization

#### See also
- [Code ownership notion page](https://www.notion.so/montaapp/Code-ownership-58ade3fceb1e4cb89138a7fc10c5a07f)
- [Repo ownership review spreadsheet](https://docs.google.com/spreadsheets/d/1LtA1kfE7YSUBEFAbP02XnmSZp5X_eBPmea6x832VFP4/edit?gid=0#gid=0)
- [Ticket - SRE-314](https://montaapp.atlassian.net/browse/SRE-314)