### PR TITLE
feat: add multi-architecture support for changelog-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ It will:
 
 If you have done your commit messages using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) the changelog will be formatted nicely in sections.
 
+## Architecture Support
+
+This action automatically detects the runner architecture and downloads the appropriate binary:
+- **x86_64** - Downloads `changelog-cli-x64`
+- **aarch64/arm64** - Downloads `changelog-cli-arm64`
+
+The action works on both standard x64 runners and ARM64 runners (e.g., `ubuntu-24.04-arm`).
+
 ## Example of Github workflow job
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,19 @@ runs:
       shell: bash
     - name: Download changelog cli
       run: |
-        curl -L -o changelog-cli https://github.com/monta-app/changelog-cli/releases/download/v1.8.0/changelog-cli
+        # Detect architecture
+        ARCH=$(uname -m)
+        if [ "$ARCH" = "x86_64" ]; then
+          BINARY_NAME="changelog-cli-x64"
+        elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+          BINARY_NAME="changelog-cli-arm64"
+        else
+          echo "Unsupported architecture: $ARCH"
+          exit 1
+        fi
+
+        echo "Downloading $BINARY_NAME for architecture $ARCH"
+        curl -L -o changelog-cli https://github.com/monta-app/changelog-cli/releases/download/v1.9.1/$BINARY_NAME
         chmod +x ./changelog-cli
       shell: bash
     - name: Run changelog cli


### PR DESCRIPTION
## Summary
Adds automatic architecture detection and multi-architecture binary support to work with changelog-cli v1.9.1.

## Changes

### action.yml
- Auto-detect runner architecture using `uname -m`
- Map x86_64 to `changelog-cli-x64`
- Map aarch64/arm64 to `changelog-cli-arm64`
- Update to changelog-cli v1.9.1 (includes ARM64 binaries)
- Exit with error for unsupported architectures

### README.md
- Document architecture support
- Note that action works on both x64 and ARM64 runners

## Benefits
- ✅ Works on standard x64 runners (ubuntu-latest)
- ✅ Works on ARM64 runners (ubuntu-24.04-arm)
- ✅ Automatic architecture detection - no configuration needed
- ✅ Uses new multi-arch changelog-cli v1.9.1

## Testing
Ready to test with changelog-cli v1.9.1 release once available.