### PR TITLE
feat: add step to collect GitHub run information

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,16 @@ runs:
         curl -L -o changelog-cli https://github.com/monta-app/changelog-cli/releases/download/v1.9.20/$BINARY_NAME
         chmod +x ./changelog-cli
       shell: bash
+    - name: Collect run information
+      run: |
+        RUN_LINK="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        TRIGGERED_BY="${{ github.actor }}"
+
+        echo "=== Run Information ==="
+        echo "Run Link: $RUN_LINK"
+        echo "Triggered By: $TRIGGERED_BY"
+        echo "======================="
+      shell: bash
     - name: Run changelog cli
       env:
         CHANGELOG_SERVICE_NAME: ${{ inputs.service-name }}


### PR DESCRIPTION
## Summary
- Added a new step after downloading the changelog CLI to collect GitHub run information
- Collects the link to the current GitHub Actions run
- Collects the GitHub username of the person who triggered the workflow
- Logs both values to the console for now
- These values can later be injected into the changelog CLI tool for display

## Changes
- Added "Collect run information" step in `action.yml`
- Uses `github.server_url`, `github.repository`, `github.run_id`, and `github.actor` context variables
- Formatted log output for easy reading

🤖 Generated with Claude Code