### PR TITLE
feat: add Docker image metadata parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ When posting to Slack, the action automatically includes metadata in a threaded 
 
 This helps track which workflow generated each changelog and provides better traceability.
 
+## Docker Image Metadata
+
+The action supports optional Docker image deployment metadata that can be included in Slack thread metadata:
+- **Docker Image**: Docker image repository URL
+- **Image Tag**: Current deployed image tag (e.g., commit SHA)
+- **Previous Image Tag**: Previous image tag for rollback reference
+
+This provides operations teams with deployment information directly in the changelog, making it easier to track what was deployed and enabling quick rollbacks if needed.
+
 ## Architecture Support
 
 This action automatically detects the runner architecture and downloads the appropriate binary:
@@ -28,6 +37,8 @@ This action automatically detects the runner architecture and downloads the appr
 The action works on both standard x64 runners and ARM64 runners (e.g., `ubuntu-24.04-arm`).
 
 ## Example of Github workflow job
+
+### Basic Example
 
 ```yaml
 create-change-log:
@@ -53,6 +64,31 @@ create-change-log:
         slack-token: <token>
         # the slack channel to post to
         slack-channel: "#releases"
+```
+
+### Example with Docker Image Metadata
+
+```yaml
+create-change-log:
+  needs: deploy
+  name: Create and publish change log
+  runs-on: ubuntu-latest
+  timeout-minutes: 5
+  steps:
+    - name: Run changelog cli action
+      uses: monta-app/changelog-cli-action@main
+      with:
+        service-name: "My Service"
+        github-release: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        jira-app-name: "myapp"
+        output: "slack"
+        slack-token: ${{ secrets.SLACK_TOKEN }}
+        slack-channel: "#releases"
+        # Docker deployment metadata (optional)
+        docker-image: "123456789.dkr.ecr.us-east-1.amazonaws.com/my-service"
+        image-tag: ${{ github.sha }}
+        previous-image-tag: ${{ needs.deploy.outputs.previous_tag }}
 ```
 
 See further documentation of options in [action.yml](./action.yml)

--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ When posting to Slack, the action automatically includes metadata in a threaded 
 
 This helps track which workflow generated each changelog and provides better traceability.
 
-## Docker Image Metadata
+## Deployment Metadata
 
-The action supports optional Docker image deployment metadata that can be included in Slack thread metadata:
+The action supports optional deployment metadata that can be included in Slack thread metadata:
+- **Stage/Environment**: Deployment stage (e.g., dev, staging, production)
 - **Docker Image**: Docker image repository URL
 - **Image Tag**: Current deployed image tag (e.g., commit SHA)
 - **Previous Image Tag**: Previous image tag for rollback reference
 
-This provides operations teams with deployment information directly in the changelog, making it easier to track what was deployed and enabling quick rollbacks if needed.
+This provides operations teams with deployment information directly in the changelog, making it easier to track what was deployed to which environment and enabling quick rollbacks if needed.
 
 ## Architecture Support
 
@@ -66,7 +67,7 @@ create-change-log:
         slack-channel: "#releases"
 ```
 
-### Example with Docker Image Metadata
+### Example with Deployment Metadata
 
 ```yaml
 create-change-log:
@@ -85,7 +86,8 @@ create-change-log:
         output: "slack"
         slack-token: ${{ secrets.SLACK_TOKEN }}
         slack-channel: "#releases"
-        # Docker deployment metadata (optional)
+        # Deployment metadata (optional)
+        stage: "production"
         docker-image: "123456789.dkr.ecr.us-east-1.amazonaws.com/my-service"
         image-tag: ${{ github.sha }}
         previous-image-tag: ${{ needs.deploy.outputs.previous_tag }}

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,15 @@ inputs:
   slack-channels:
     description: "A comma-separated list of Slack channels to post the changelog to"
     required: false
+  docker-image:
+    description: "Docker image repository URL (e.g., 123456789.dkr.ecr.us-east-1.amazonaws.com/my-service)"
+    required: false
+  image-tag:
+    description: "Current Docker image tag being deployed (e.g., commit SHA)"
+    required: false
+  previous-image-tag:
+    description: "Previous Docker image tag for rollback reference"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -82,5 +91,8 @@ runs:
         CHANGELOG_SLACK_CHANNELS: ${{ inputs.slack-channels }}
         CHANGELOG_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         CHANGELOG_TRIGGERED_BY: ${{ github.actor }}
+        CHANGELOG_DOCKER_IMAGE: ${{ inputs.docker-image }}
+        CHANGELOG_IMAGE_TAG: ${{ inputs.image-tag }}
+        CHANGELOG_PREVIOUS_IMAGE_TAG: ${{ inputs.previous-image-tag }}
       run: ./changelog-cli
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,9 @@ inputs:
   previous-image-tag:
     description: "Previous Docker image tag for rollback reference"
     required: false
+  stage:
+    description: "Deployment stage/environment (e.g., dev, staging, production)"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -91,6 +94,7 @@ runs:
         CHANGELOG_SLACK_CHANNELS: ${{ inputs.slack-channels }}
         CHANGELOG_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         CHANGELOG_TRIGGERED_BY: ${{ github.actor }}
+        CHANGELOG_STAGE: ${{ inputs.stage }}
         CHANGELOG_DOCKER_IMAGE: ${{ inputs.docker-image }}
         CHANGELOG_IMAGE_TAG: ${{ inputs.image-tag }}
         CHANGELOG_PREVIOUS_IMAGE_TAG: ${{ inputs.previous-image-tag }}


### PR DESCRIPTION
## Summary

Adds support for optional deployment metadata parameters to the changelog-cli GitHub Action, enabling teams to display environment and Docker image information in Slack thread metadata.

## Problem

The changelog-cli tool now supports deployment metadata (added in monta-app/changelog-cli#202), but the GitHub Action doesn't expose these parameters yet. Teams need a way to pass deployment information through the action to include it in Slack changelogs.

## Solution

Added four new optional input parameters to the action that map to the changelog-cli deployment metadata feature:

1. **`stage`** - Deployment stage/environment (e.g., dev, staging, production)
2. **`docker-image`** - Docker image repository URL
3. **`image-tag`** - Current deployed image tag (e.g., commit SHA)
4. **`previous-image-tag`** - Previous image tag for rollback reference

## Changes

### action.yml

Added four new optional inputs:

```yaml
inputs:
  stage:
    description: "Deployment stage/environment (e.g., dev, staging, production)"
    required: false
  docker-image:
    description: "Docker image repository URL (e.g., 123456789.dkr.ecr.us-east-1.amazonaws.com/my-service)"
    required: false
  image-tag:
    description: "Current Docker image tag being deployed (e.g., commit SHA)"
    required: false
  previous-image-tag:
    description: "Previous Docker image tag for rollback reference"
    required: false
```

Added corresponding environment variables:

```yaml
env:
  CHANGELOG_STAGE: ${{ inputs.stage }}
  CHANGELOG_DOCKER_IMAGE: ${{ inputs.docker-image }}
  CHANGELOG_IMAGE_TAG: ${{ inputs.image-tag }}
  CHANGELOG_PREVIOUS_IMAGE_TAG: ${{ inputs.previous-image-tag }}
```

### README.md

- Renamed section from "Docker Image Metadata" to "Deployment Metadata"
- Added stage/environment parameter documentation
- Added example workflow showing how to use all deployment parameters
- Documented common use cases (using `${{ github.sha }}` for image tags)

## Usage Example

```yaml
- name: Run changelog cli action
  uses: monta-app/changelog-cli-action@main
  with:
    service-name: "My Service"
    github-release: true
    github-token: ${{ secrets.GITHUB_TOKEN }}
    output: "slack"
    slack-token: ${{ secrets.SLACK_TOKEN }}
    slack-channel: "#releases"
    # Deployment metadata (optional)
    stage: "production"
    docker-image: "123456789.dkr.ecr.us-east-1.amazonaws.com/my-service"
    image-tag: ${{ github.sha }}
    previous-image-tag: ${{ needs.deploy.outputs.previous_tag }}
```

## Slack Output

When these parameters are provided, the Slack thread metadata will include:

```
Stage/Environment: production
Docker Image: 123456789.dkr.ecr.us-east-1.amazonaws.com/my-service
Image Tag: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0
Previous Image Tag (Rollback): 9z8y7x6w5v4u3t2s1r0q9p8o7n6m5l4k3j2i1h0
```

## Benefits

1. **Environment visibility** - Clear indication of which environment was deployed to
2. **Operational visibility** - Teams can see exactly what Docker image was deployed
3. **Quick rollback reference** - Previous image tag readily available in Slack
4. **Deployment tracking** - Correlate changelogs with specific container images and environments
5. **Easy integration** - Works seamlessly with existing workflows using `${{ github.sha }}`
6. **Optional** - Backwards compatible, parameters are optional
7. **Non-technical friendly** - "Stage/Environment" label is clear for all stakeholders

## Dependencies

Requires changelog-cli v1.9.34 or later (when monta-app/changelog-cli#202 is released) for the deployment metadata feature support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)