### PR TITLE
feat: add JIRA credentials inputs for ticket validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,12 @@ inputs:
   jira-app-name:
     description: "Name of the Jira app used for generating Jira issue links"
     required: false
+  jira-email:
+    description: "Email for JIRA API authentication (used for ticket validation)"
+    required: false
+  jira-token:
+    description: "JIRA API token for authentication (used for ticket validation)"
+    required: false
   output:
     description: "Output mode (console,slack)"
     required: true
@@ -85,6 +91,8 @@ runs:
         CHANGELOG_GITHUB_UPDATE: ${{ inputs.github-update }}
         CHANGELOG_GITHUB_TOKEN: ${{ inputs.github-token }}
         CHANGELOG_JIRA_APP_NAME: ${{ inputs.jira-app-name }}
+        CHANGELOG_JIRA_EMAIL: ${{ inputs.jira-email }}
+        CHANGELOG_JIRA_TOKEN: ${{ inputs.jira-token }}
         CHANGELOG_VERSION_MODE: ${{ inputs.version-mode }}
         CHANGELOG_GITHUB_TAG_PATTERN: ${{ inputs.github-tag-pattern }}
         CHANGELOG_GITHUB_PATH_EXCLUDE_PATTERN: ${{ inputs.github-path-exclude-pattern }}


### PR DESCRIPTION
## Summary

Adds `jira-email` and `jira-token` inputs to the GitHub Action to enable JIRA ticket validation functionality introduced in [monta-app/changelog-cli#197](https://github.com/monta-app/changelog-cli/pull/197).

## Changes

### New Action Inputs
- **jira-email** - Email for JIRA API authentication (used for ticket validation)
- **jira-token** - JIRA API token for authentication (used for ticket validation)

Both inputs are optional and map to the `CHANGELOG_JIRA_EMAIL` and `CHANGELOG_JIRA_TOKEN` environment variables consumed by changelog-cli v1.9.32+.

## Usage

Users can now pass JIRA credentials as GitHub secrets to enable automatic validation and filtering of invalid JIRA tickets:

```yaml
- uses: monta-app/changelog-cli-action@v1
  with:
    service-name: my-service
    jira-app-name: montaapp
    jira-email: ${{ secrets.JIRA_EMAIL }}
    jira-token: ${{ secrets.JIRA_TOKEN }}
    # ... other inputs
```

## Backward Compatibility

Fully backward compatible - the action works without these credentials (no validation). Validation only runs when both JIRA credentials are provided.

## Test Plan

- [ ] Verify action runs successfully without JIRA credentials
- [ ] Verify action runs successfully with JIRA credentials from secrets
- [ ] Verify changelog-cli receives the environment variables correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)