### PR TITLE
docs: update Slack channel from #releases to #info-releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ create-change-log:
         # the slack token - use a reference to a secret
         slack-token: <token>
         # the slack channel to post to
-        slack-channel: "#releases"
+        slack-channel: "#info-releases"
 ```
 
 ### Example with Deployment Metadata
@@ -85,7 +85,7 @@ create-change-log:
         jira-app-name: "myapp"
         output: "slack"
         slack-token: ${{ secrets.SLACK_TOKEN }}
-        slack-channel: "#releases"
+        slack-channel: "#info-releases"
         # Deployment metadata (optional)
         stage: "production"
         docker-image: "123456789.dkr.ecr.us-east-1.amazonaws.com/my-service"


### PR DESCRIPTION
Updates the README documentation to reflect the new Slack channel name for release notifications.

**Changes:**
- Updated both example configurations
- `#releases` → `#info-releases`

🤖 Generated with [Claude Code](https://claude.com/claude-code)