### PR TITLE
feat: add deployment timing parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ The action supports optional deployment metadata that can be included in Slack t
 - **Docker Image**: Docker image repository URL
 - **Image Tag**: Current deployed image tag (e.g., commit SHA)
 - **Previous Image Tag**: Previous image tag for rollback reference
+- **Deployment Start Time**: Timestamp when deployment started (ISO 8601 format recommended)
+- **Deployment End Time**: Timestamp when deployment finished (ISO 8601 format recommended)
+- **Deployment URL**: Link to the deployment system (ArgoCD, Cloudflare, etc.)
 
-This provides operations teams with deployment information directly in the changelog, making it easier to track what was deployed to which environment and enabling quick rollbacks if needed.
+This provides operations teams with deployment information directly in the changelog, making it easier to track what was deployed to which environment, when it was deployed, and enabling quick rollbacks and regression debugging if needed.
 
 ## Architecture Support
 
@@ -91,6 +94,9 @@ create-change-log:
         docker-image: "123456789.dkr.ecr.us-east-1.amazonaws.com/my-service"
         image-tag: ${{ github.sha }}
         previous-image-tag: ${{ needs.deploy.outputs.previous_tag }}
+        deployment-start-time: ${{ needs.deploy.outputs.start_time }}
+        deployment-end-time: ${{ needs.deploy.outputs.end_time }}
+        deployment-url: "https://argocd.monta.app/applications/argocd/my-service-production"
 ```
 
 See further documentation of options in [action.yml](./action.yml)

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,15 @@ inputs:
   stage:
     description: "Deployment stage/environment (e.g., dev, staging, production)"
     required: false
+  deployment-start-time:
+    description: "Timestamp when the deployment started (ISO 8601 format recommended)"
+    required: false
+  deployment-end-time:
+    description: "Timestamp when the deployment finished (ISO 8601 format recommended)"
+    required: false
+  deployment-url:
+    description: "URL to the deployment system (e.g., ArgoCD, Cloudflare)"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -106,5 +115,8 @@ runs:
         CHANGELOG_DOCKER_IMAGE: ${{ inputs.docker-image }}
         CHANGELOG_IMAGE_TAG: ${{ inputs.image-tag }}
         CHANGELOG_PREVIOUS_IMAGE_TAG: ${{ inputs.previous-image-tag }}
+        CHANGELOG_DEPLOYMENT_START_TIME: ${{ inputs.deployment-start-time }}
+        CHANGELOG_DEPLOYMENT_END_TIME: ${{ inputs.deployment-end-time }}
+        CHANGELOG_DEPLOYMENT_URL: ${{ inputs.deployment-url }}
       run: ./changelog-cli
       shell: bash


### PR DESCRIPTION
## Summary

Adds support for three new deployment timing parameters in the GitHub Action, matching the newly added features in changelog-cli v1.9.49+.

## New Parameters

**1. `deployment-start-time`**
- Timestamp when the deployment started (ISO 8601 format recommended)
- Maps to `CHANGELOG_DEPLOYMENT_START_TIME` environment variable

**2. `deployment-end-time`**
- Timestamp when the deployment finished (ISO 8601 format recommended)
- Maps to `CHANGELOG_DEPLOYMENT_END_TIME` environment variable

**3. `deployment-url`**
- URL to the deployment system (ArgoCD, Cloudflare, etc.)
- Maps to `CHANGELOG_DEPLOYMENT_URL` environment variable

## Use Cases

✅ **Regression Investigation**: Pinpoint exact deployment time to correlate with error spikes
✅ **Performance Tracking**: Calculate deployment duration
✅ **Incident Response**: Quickly access deployment system details during incidents
✅ **Audit Trail**: Complete record of when changes were deployed
✅ **Rollback Context**: Direct link to deployment system for rollback procedures
✅ **System Agnostic**: Works with any deployment system (ArgoCD, Cloudflare, etc.)

## Example Usage

```yaml
- uses: monta-app/changelog-cli-action@main
  with:
    service-name: "My Service"
    github-release: true
    github-token: ${{ secrets.GITHUB_TOKEN }}
    output: "slack"
    slack-token: ${{ secrets.SLACK_TOKEN }}
    slack-channel: "#info-releases"
    stage: "production"
    deployment-start-time: ${{ needs.deploy.outputs.start_time }}
    deployment-end-time: ${{ needs.deploy.outputs.end_time }}
    deployment-url: "https://argocd.monta.app/applications/argocd/my-service-production"
```

## Changes

- Added 3 new optional input parameters to `action.yml`
- Added corresponding environment variable mappings
- Updated README with documentation and examples
- All parameters are optional (backward compatible)

## Related

- Requires changelog-cli v1.9.49 or later (already set in action)
- Related to changelog-cli PR #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)