### PR TITLE
feat: add support for PR and JIRA commenting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,14 @@ inputs:
   deployment-url:
     description: "URL to the deployment system (e.g., ArgoCD, Cloudflare)"
     required: false
+  comment-on-prs:
+    description: "Comment on PRs with production deployment information (requires stage=production and deployment times)"
+    required: false
+    default: 'false'
+  comment-on-jira:
+    description: "Comment on JIRA tickets with production deployment information (requires stage=production and deployment times)"
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -118,5 +126,7 @@ runs:
         CHANGELOG_DEPLOYMENT_START_TIME: ${{ inputs.deployment-start-time }}
         CHANGELOG_DEPLOYMENT_END_TIME: ${{ inputs.deployment-end-time }}
         CHANGELOG_DEPLOYMENT_URL: ${{ inputs.deployment-url }}
+        CHANGELOG_COMMENT_ON_PRS: ${{ inputs.comment-on-prs }}
+        CHANGELOG_COMMENT_ON_JIRA: ${{ inputs.comment-on-jira }}
       run: ./changelog-cli
       shell: bash


### PR DESCRIPTION
## Summary

Adds support for the new PR and JIRA commenting features to the changelog-cli-action. This allows services using the action to automatically notify stakeholders when features are deployed to production.

**Relates to: SRE-1580**

## Changes

### New Input Parameters

1. **`comment-on-prs`** (optional, default: `false`)
   - Posts deployment information on all PRs included in the release
   - Requires `stage: "production"`, deployment times, and Slack URL

2. **`comment-on-jira`** (optional, default: `false`)
   - Posts deployment information on all JIRA tickets referenced in commits
   - Requires `stage: "production"`, deployment times, Slack URL, and JIRA credentials

### Documentation Updates

- Added new "PR and JIRA Commenting" section explaining the feature
- Added example showing how to enable these features
- Added note about using bot token (e.g., `MONTA_BOT_TOKEN`) for PR comments
- Updated existing examples for clarity

## Requirements for Commenting

Both features require:
- ✅ `stage: "production"` - Only comments on production deployments
- ✅ `deployment-start-time` and `deployment-end-time` - For timing information
- ✅ Slack announcement posted - Provides link in comments
- ✅ `comment-on-prs: true` or `comment-on-jira: true` - Explicit opt-in

For JIRA commenting, additionally requires:
- ✅ `jira-email` - JIRA account email
- ✅ `jira-token` - JIRA API token  
- ✅ `jira-app-name` - JIRA workspace name

## Comment Format

Comments include:
- **Large heading**: "🚀 Production Deployment"
- **Release version**: Tag name
- **Full changelog**: Grouped by type (features, fixes, etc.)
- **Deployment timing**: Human-readable format (e.g., "Jan 13, 2026 at 17:35 UTC → 17:37 UTC")
- **Links**: Changeset, deployment system, and Slack announcement

## Example Usage

```yaml
- name: Run changelog cli action
  uses: monta-app/changelog-cli-action@main
  with:
    service-name: "My Service"
    github-release: true
    github-token: ${{ secrets.MONTA_BOT_TOKEN }}  # Use bot token!
    jira-app-name: "myapp"
    jira-email: ${{ secrets.JIRA_EMAIL }}
    jira-token: ${{ secrets.JIRA_TOKEN }}
    output: "slack"
    slack-token: ${{ secrets.SLACK_TOKEN }}
    slack-channel: "#info-releases"
    stage: "production"
    deployment-start-time: ${{ needs.deploy.outputs.start_time }}
    deployment-end-time: ${{ needs.deploy.outputs.end_time }}
    deployment-url: "https://argocd.example.com/app"
    # Enable PR and JIRA commenting
    comment-on-prs: true
    comment-on-jira: true
```

## Benefits

- **Transparency**: Contributors and stakeholders see when their work reaches production
- **Traceability**: PR and JIRA tickets have deployment history
- **Consistency**: Same notification pattern across all Monta services
- **Opt-in**: Features are disabled by default, services can enable as needed
- **Flexible**: Can enable PR comments only, JIRA comments only, or both

## Testing

This will be tested by:
1. Merging this PR
2. Updating a service's deployment workflow to use these parameters
3. Deploying that service to production
4. Verifying comments appear on PRs and JIRA tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)