### PR TITLE
chore: update changelog-cli to v1.9.68

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
         fi
 
         echo "Downloading $BINARY_NAME for architecture $ARCH"
-        curl -L -o changelog-cli https://github.com/monta-app/changelog-cli/releases/download/v1.9.67/$BINARY_NAME
+        curl -L -o changelog-cli https://github.com/monta-app/changelog-cli/releases/download/v1.9.68/$BINARY_NAME
         chmod +x ./changelog-cli
       shell: bash
     - name: Run changelog cli


### PR DESCRIPTION
Automatically generated PR to update changelog-cli version.

## Changes
- Update changelog-cli to **v1.9.68**

## Release Notes
See the [changelog-cli v1.9.68 release](https://github.com/monta-app/changelog-cli/releases/tag/v1.9.68) for details.

🤖 Automated by changelog-cli release workflow
_Updated: 2026-03-25 08:35:58 UTC_