### PR TITLE
chore: Do not pin monta-app github actions [NOJIRA]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,13 @@
   ],
   "semanticCommits": "enabled",
   "prConcurrentLimit": 2,
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "description": "Do not pin internal monta-app GitHub Actions — these intentionally track @main",
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": ["^monta-app/"],
+      "pinDigests": false
+    }
+  ]
 }


### PR DESCRIPTION
Overlooked that this repo also used a few monta-app github actions - we don't want to pin those